### PR TITLE
Config health checks and Prometheus in test environment

### DIFF
--- a/.nais/test/nais.yaml
+++ b/.nais/test/nais.yaml
@@ -40,13 +40,18 @@ spec:
 
   liveness:
     path: /health/liveness
-    port: 10210
+    port: 10220
   readiness:
     path: /health/readiness
-    port: 10210
+    port: 10220
   startup:
     path: /health/readiness
-    port: 10210
+    port: 10220
+  
+  prometheus:
+    enabled: true
+    path: /prometheus
+    port: 10220
 
   env:
     - name: MICRONAUT_CONFIG_FILES

--- a/.nais/test/nais.yaml
+++ b/.nais/test/nais.yaml
@@ -131,6 +131,17 @@ data:
           expire-after-access: 15m
         cloud-identity-service-cache:
           expire-after-write: 1m
+        
+      metrics:
+        sensitive: false
+        enabled: true
+        tags:
+          application: ${micronaut.application.name}
+        export:
+          prometheus:
+            enabled: true
+            descriptions: true
+            step: PT1M
 
       router:
         static-resources:
@@ -152,8 +163,19 @@ data:
         intercept-url-map:
           - pattern: /api-docs/**
             httpMethod: GET
-            access:
-              - isAnonymous()
+            access: isAnonymous()
+          - pattern: /health/**
+            http-method: GET
+            access: isAnonymous()
+          - pattern: /metrics/**
+            http-method: GET
+            access: isAnonymous()
+          - pattern: /prometheus/**
+            http-method: GET
+            access: isAnonymous()
+          - pattern: /**
+            access: isAuthenticated()
+          
         token:
           name-key: email
           jwt:
@@ -168,13 +190,20 @@ data:
           enabled: false
 
     endpoints:
+      all:
+        port: 10220
       prometheus:
         sensitive: false
       info:
         enabled: true
         sensitive: false
       health:
-        enabled: true
+        sensitive: false
+        details-visible: ANONYMOUS
+        service-http-client: 
+          enabled: true
+        monitor:
+          enabled: true
 
     logger:
       levels:

--- a/.nais/test/nais.yaml
+++ b/.nais/test/nais.yaml
@@ -121,10 +121,14 @@ data:
             pool:
               enabled: true
               max-connections: 50
+            health-check: true
+            health-check-interval: 15s
           cloud-identity-service:
             url: 'https://cloudidentity.googleapis.com'
             path: '/v1'
             read-timeout: 60s
+            health-check: true
+            health-check-interval: 15s
 
       caches:
         secrets:
@@ -200,8 +204,6 @@ data:
       health:
         sensitive: false
         details-visible: ANONYMOUS
-        service-http-client: 
-          enabled: true
         monitor:
           enabled: true
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>no.ssb.dapla.dlp.pseudo</groupId>
   <artifactId>pseudo-service</artifactId>
-  <version>3.1.12-SNAPSHOT</version>
+  <version>3.1.13-SNAPSHOT</version>
   <name>pseudo-service</name>
 
   <parent>

--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,11 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
+      <groupId>io.micronaut.micrometer</groupId>
+      <artifactId>micronaut-micrometer-registry-prometheus</artifactId>
+      <version>5.10.1</version>
+    </dependency>
+    <dependency>
       <groupId>io.micronaut.cache</groupId>
       <artifactId>micronaut-cache-core</artifactId>
       <scope>compile</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>no.ssb.dapla.dlp.pseudo</groupId>
   <artifactId>pseudo-service</artifactId>
-  <version>3.1.13-SNAPSHOT</version>
+  <version>3.1.12-SNAPSHOT</version>
   <name>pseudo-service</name>
 
   <parent>

--- a/src/main/java/no/ssb/dlp/pseudo/service/health/LivenessIndicator.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/health/LivenessIndicator.java
@@ -7,9 +7,10 @@ import io.micronaut.health.HealthStatus;
 import io.micronaut.management.health.indicator.HealthIndicator;
 import io.micronaut.management.health.indicator.HealthResult;
 import io.micronaut.management.health.indicator.annotation.Liveness;
+import jakarta.inject.Singleton;
 import reactor.core.publisher.Mono;
 
-@jakarta.inject.Singleton
+@Singleton
 @Liveness
 public class LivenessIndicator implements HealthIndicator {
     private static final String LIVENESS_NAME = "liveness";

--- a/src/main/java/no/ssb/dlp/pseudo/service/health/LivenessIndicator.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/health/LivenessIndicator.java
@@ -1,0 +1,23 @@
+package no.ssb.dlp.pseudo.service.health;
+
+
+import org.reactivestreams.Publisher;
+
+import io.micronaut.health.HealthStatus;
+import io.micronaut.management.health.indicator.HealthIndicator;
+import io.micronaut.management.health.indicator.HealthResult;
+import io.micronaut.management.health.indicator.annotation.Liveness;
+import reactor.core.publisher.Mono;
+
+@jakarta.inject.Singleton
+@Liveness
+public class LivenessIndicator implements HealthIndicator {
+    private static final String LIVENESS_NAME = "liveness";
+
+    @Override
+    public Publisher<HealthResult> getResult() {
+        return Mono.just(HealthResult.builder(LIVENESS_NAME)
+                .status(HealthStatus.UP)
+                .build());
+    }
+}

--- a/src/test/java/no/ssb/dlp/pseudo/service/health/HealthTest.java
+++ b/src/test/java/no/ssb/dlp/pseudo/service/health/HealthTest.java
@@ -1,0 +1,26 @@
+package no.ssb.dlp.pseudo.service.health;
+
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.client.HttpClient;
+import io.micronaut.http.client.annotation.Client;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import org.junit.jupiter.api.Test;
+
+import jakarta.inject.Inject;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@MicronautTest  
+public class HealthTest {
+
+    @Inject
+    @Client("/") 
+    HttpClient client;
+
+    @Test
+    public void healthEndpointExposed() {
+        HttpStatus status = client.toBlocking().retrieve(HttpRequest.GET("/health"), HttpStatus.class); 
+        assertEquals(HttpStatus.OK, status);
+    }
+}


### PR DESCRIPTION
We now serve metrics and health check endpoints on port `10220`, not on the same port as regular requests, `10210`. This is to avoid requests from outside the cluster, and possibly the internet, being able to access metrics and status of the application. These endpoints need to be unauthenticated to allow for cluster services to access them

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/statisticsnorway/pseudo-service/122)
<!-- Reviewable:end -->
