### PR TITLE
Increase memory request for prod

### DIFF
--- a/.nais/prod/nais.yaml
+++ b/.nais/prod/nais.yaml
@@ -18,7 +18,7 @@ spec:
   resources:
     requests:
       cpu: 300m
-      memory: 2Gi
+      memory: 12Gi
     limits:
       memory: 12Gi
 

--- a/.nais/prod/nais.yaml
+++ b/.nais/prod/nais.yaml
@@ -18,7 +18,8 @@ spec:
   resources:
     requests:
       cpu: 300m
-      memory: 12Gi
+      memory: 12Gi  # This should be equal to the upper limit of the app, as Kubernetes
+                    # pods are only guaranteed to get the resources defined in "requests"
     limits:
       memory: 12Gi
 


### PR DESCRIPTION
Kubernetes pods are scheduled to a node based on request, not limit, so request should be equal to the limit

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/statisticsnorway/pseudo-service/132)
<!-- Reviewable:end -->
