### PR TITLE
Increase grace period

### DIFF
--- a/.nais/prod/nais.yaml
+++ b/.nais/prod/nais.yaml
@@ -12,6 +12,7 @@ metadata:
 spec:
   image: "{{ image }}"  # Injected from the GitHub Action
   port: 10210
+  terminationGracePeriodSeconds: 180
   replicas:
     max: 10
     min: 2

--- a/.nais/test/nais.yaml
+++ b/.nais/test/nais.yaml
@@ -12,6 +12,7 @@ metadata:
 spec:
   image: "{{ image }}"  # Injected from the GitHub Action
   port: 10210
+  terminationGracePeriodSeconds: 180
   replicas:
     max: 5
     min: 2


### PR DESCRIPTION
This should hoppefully increase the chance that a request is processed when the pod scales down. Sadly, this is not guaranteed as the max grace period in NAIS is 180 seconds (3 minutes), not the potential maximum of 10 miinutes.
https://doc.nais.io/workloads/application/reference/application-spec/?h=grace#terminationgraceperiodseconds

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/statisticsnorway/pseudo-service/135)
<!-- Reviewable:end -->
