### PR TITLE
Reapply "Revert changes to pseudo metadata (#133)" (#134)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <ssb-datadoc-model.url>https://maven.pkg.github.com/statisticsnorway/ssb-datadoc-model</ssb-datadoc-model.url>
     <github.repository>statisticsnorway/pseudo-service</github.repository>
     <exec.mainClass>no.ssb.dlp.pseudo.service.Application</exec.mainClass>
-    <dapla-datadoc-model.version>1.4</dapla-datadoc-model.version>
+    <dapla-datadoc-model.version>1.2</dapla-datadoc-model.version>
     <artifactregistry-maven-wagon.version>2.2.1</artifactregistry-maven-wagon.version>
     <dapla-dlp-pseudo-core.version>2.0.6</dapla-dlp-pseudo-core.version>
     <micronaut.version>4.7.6</micronaut.version>

--- a/src/main/java/no/ssb/dlp/pseudo/service/pseudo/PseudoResponseSerializer.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/pseudo/PseudoResponseSerializer.java
@@ -19,7 +19,7 @@ public class PseudoResponseSerializer {
         return enclose(data.concatMap(item -> Flowable.just(item, ","))
                 .startWith("\"data\": [")
                 .skipLast(1) // Skip last comma
-                .concatWith(Flowable.just("], \"datadoc_metadata\": {\"variables\": ["))
+                .concatWith(Flowable.just("], \"datadoc_metadata\": {\"pseudo_variables\": ["))
                 .concatWith(metadata.concatMap(item -> Flowable.just(item, ",")).skipLast(1))
                 .concatWith(Flowable.just("]}, \"metrics\": ["))
                 .concatWith(metrics.concatMap(item -> Flowable.just(item, ",")).skipLast(1))

--- a/src/main/java/no/ssb/dlp/pseudo/service/pseudo/RecordMapProcessorFactory.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/pseudo/RecordMapProcessorFactory.java
@@ -148,6 +148,7 @@ public class RecordMapProcessorFactory {
                 metadataProcessor.addMetadata(FieldMetadata.builder()
                         .shortName(field.getName())
                         .dataElementPath(normalizePath(field.getPath())) // Skip leading slash and use dot as separator
+                        .dataElementPattern(match.getRule().getPattern())
                         .encryptionKeyReference(funcDeclaration.getArgs().getOrDefault(KEY_REFERENCE, null))
                         .encryptionAlgorithm(match.getFunc().getAlgorithm())
                         .stableIdentifierVersion(sidSnapshotDate)

--- a/src/main/java/no/ssb/dlp/pseudo/service/pseudo/metadata/FieldMetadata.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/pseudo/metadata/FieldMetadata.java
@@ -2,9 +2,8 @@ package no.ssb.dlp.pseudo.service.pseudo.metadata;
 
 import lombok.Builder;
 import lombok.Value;
-import no.ssb.dapla.metadata.datadoc.EncryptionAlgorithmParameter;
-import no.ssb.dapla.metadata.datadoc.Pseudonymization;
-import no.ssb.dapla.metadata.datadoc.Variable;
+import no.ssb.dapla.metadata.EncryptionAlgorithmParameter;
+import no.ssb.dapla.metadata.PseudoVariable;
 
 import java.util.List;
 import java.util.Map;
@@ -18,34 +17,24 @@ public class FieldMetadata {
 
     String shortName;
     String dataElementPath;
+    String dataElementPattern;
     String encryptionKeyReference;
     String encryptionAlgorithm;
     String stableIdentifierVersion;
     boolean stableIdentifierType;
     Map<String, String> encryptionAlgorithmParameters;
 
-    // Create a partial datadoc variable which only contains pseudonymization information
-    public Variable toDatadocVariable() {
-        final var pseudonymization =
-                Pseudonymization.builder()
-                .withEncryptionAlgorithm(encryptionAlgorithm)
-                .withEncryptionKeyReference(encryptionKeyReference)
-                .withEncryptionAlgorithmParameters(
-                 toEncryptionAlgorithmParameters()
-                )
-                .withStableIdentifierVersion(stableIdentifierVersion)
-                .withStableIdentifierType(stableIdentifierType ? STABLE_IDENTIFIER_TYPE : null)
-                .build();
-        return Variable.builder()
+    public PseudoVariable toDatadocPseudoVariable() {
+        return PseudoVariable.builder()
                 .withShortName(shortName)
                 .withDataElementPath(dataElementPath)
-                .withPseudonymization(pseudonymization)
-                // we explicitly set these keys to 'null' so that their keys don't show up in the serialized json object
-                .withName(null)
-                .withPopulationDescription(null)
-                .withComment(null)
-                .withInvalidValueDescription(null)
-                .withCustomType(null)
+                .withDataElementPattern(dataElementPattern)
+                .withEncryptionKeyReference(encryptionKeyReference)
+                .withEncryptionAlgorithm(encryptionAlgorithm)
+                .withEncryptionAlgorithmParameters(
+                        toEncryptionAlgorithmParameters())
+                .withStableIdentifierVersion(stableIdentifierVersion)
+                .withStableIdentifierType(stableIdentifierType ? STABLE_IDENTIFIER_TYPE : null)
                 .build();
     }
 

--- a/src/main/java/no/ssb/dlp/pseudo/service/pseudo/metadata/PseudoMetadataProcessor.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/pseudo/metadata/PseudoMetadataProcessor.java
@@ -35,7 +35,7 @@ public class PseudoMetadataProcessor {
         metrics.onNext(fieldMetric);
     }
     public Publisher<String> getMetadata() {
-        return datadocMetadata.map(FieldMetadata::toDatadocVariable).map(Json::from);
+        return datadocMetadata.map(FieldMetadata::toDatadocPseudoVariable).map(Json::from);
     }
     public Publisher<String> getLogs() {
         return logs.map(Json::from);

--- a/src/test/java/no/ssb/dlp/pseudo/service/pseudo/DepseudoFieldTest.java
+++ b/src/test/java/no/ssb/dlp/pseudo/service/pseudo/DepseudoFieldTest.java
@@ -44,6 +44,7 @@ class DepseudoFieldTest {
         processor.addMetadata(FieldMetadata.builder()
                 .shortName("shortName")
                 .dataElementPath("path")
+                .dataElementPattern("pattern")
                 .encryptionKeyReference("pattern")
                 .encryptionAlgorithm("algorithm")
                 .encryptionAlgorithmParameters(Map.of("key", "value"))
@@ -78,21 +79,20 @@ class DepseudoFieldTest {
                        "processedValue v2"
                      ],
                      "datadoc_metadata": {
-                        "variables": [
+                        "pseudo_variables": [
                            {
                              "short_name": "shortName",
                              "data_element_path": "path",
-                             "pseudonymization": {
-                               "encryption_key_reference": "pattern",
-                               "encryption_algorithm": "algorithm",
-                               "stable_identifier_version": "stableIdVersion",
-                               "stable_identifier_type": "FREG_SNR",
-                                "encryption_algorithm_parameters": [
-                                  {
-                                    "key": "value"
-                                  }
-                                ]
-                             }
+                             "data_element_pattern": "pattern",
+                             "encryption_key_reference": "pattern",
+                             "encryption_algorithm": "algorithm",
+                             "stable_identifier_version": "stableIdVersion",
+                             "stable_identifier_type": "FREG_SNR",
+                              "encryption_algorithm_parameters": [
+                                {
+                                  "key": "value"
+                                }
+                              ]
                            }
                         ]
                       },

--- a/src/test/java/no/ssb/dlp/pseudo/service/pseudo/PseudoFieldTest.java
+++ b/src/test/java/no/ssb/dlp/pseudo/service/pseudo/PseudoFieldTest.java
@@ -73,6 +73,7 @@ class PseudoFieldTest {
         processor.addMetadata(FieldMetadata.builder()
                 .shortName("shortName")
                 .dataElementPath("path")
+                .dataElementPattern("pattern")
                 .encryptionKeyReference("pattern")
                 .encryptionAlgorithm("algorithm")
                 .encryptionAlgorithmParameters(Map.of("key", "value"))
@@ -107,21 +108,20 @@ class PseudoFieldTest {
                      "processedValue v2"
                    ],
                    "datadoc_metadata": {
-                     "variables": [
+                     "pseudo_variables": [
                        {
                          "short_name": "shortName",
                          "data_element_path": "path",
-                         "pseudonymization": {
-                           "stable_identifier_type": "FREG_SNR",
-                           "stable_identifier_version": "stableIdVersion",
-                           "encryption_algorithm": "algorithm",
-                           "encryption_key_reference": "pattern",
-                           "encryption_algorithm_parameters": [
-                             {
-                               "key": "value"
-                             }
-                           ]
-                         }
+                         "data_element_pattern": "pattern",
+                         "stable_identifier_type": "FREG_SNR",
+                         "stable_identifier_version": "stableIdVersion",
+                         "encryption_algorithm": "algorithm",
+                         "encryption_key_reference": "pattern",
+                         "encryption_algorithm_parameters": [
+                           {
+                             "key": "value"
+                           }
+                         ]
                        }
                      ]
                    },

--- a/src/test/java/no/ssb/dlp/pseudo/service/pseudo/PseudoResponseSerializerTest.java
+++ b/src/test/java/no/ssb/dlp/pseudo/service/pseudo/PseudoResponseSerializerTest.java
@@ -49,7 +49,7 @@ class PseudoResponseSerializerTest {
                        }
                      ],
                      "datadoc_metadata": {
-                       "variables": [
+                       "pseudo_variables": [
                          {
                            "variable_descriptions": {
                              "name": {

--- a/src/test/java/no/ssb/dlp/pseudo/service/pseudo/RepseudoFieldTest.java
+++ b/src/test/java/no/ssb/dlp/pseudo/service/pseudo/RepseudoFieldTest.java
@@ -42,6 +42,7 @@ class RepseudoFieldTest {
         processor.addMetadata(FieldMetadata.builder()
                 .shortName("shortName")
                 .dataElementPath("path")
+                .dataElementPattern("pattern")
                 .encryptionKeyReference("pattern")
                 .encryptionAlgorithm("algorithm")
                 .encryptionAlgorithmParameters(Map.of("key", "value"))
@@ -76,21 +77,20 @@ class RepseudoFieldTest {
                        "processedValue v2"
                      ],
                      "datadoc_metadata": {
-                        "variables": [
+                        "pseudo_variables": [
                            {
                              "short_name": "shortName",
                              "data_element_path": "path",
-                             "pseudonymization": {
-                               "encryption_key_reference": "pattern",
-                               "encryption_algorithm": "algorithm",
-                               "stable_identifier_version": "stableIdVersion",
-                               "stable_identifier_type": "FREG_SNR",
-                                "encryption_algorithm_parameters": [
-                                  {
-                                    "key": "value"
-                                  }
-                                ]
-                             }
+                             "data_element_pattern": "pattern",
+                             "encryption_key_reference": "pattern",
+                             "encryption_algorithm": "algorithm",
+                             "stable_identifier_version": "stableIdVersion",
+                             "stable_identifier_type": "FREG_SNR",
+                              "encryption_algorithm_parameters": [
+                                {
+                                  "key": "value"
+                                }
+                              ]
                            }
                         ]
                       },


### PR DESCRIPTION
This reverts commit dd24acddd0f06acef4a38fd251346e346abd1484.

Because of the failed deploy of `dapla-toolbelt-pseudo v3.0.0` last week in kildomaten we're now reverting this change again so that users in the test environment won't be affected. These changes were never released to the production environment.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/statisticsnorway/pseudo-service/136)
<!-- Reviewable:end -->
