### PR TITLE
Remove indices from 'name' for purposes of pseudo processing

### DIFF
--- a/src/main/java/no/ssb/dlp/pseudo/service/pseudo/PseudoField.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/pseudo/PseudoField.java
@@ -62,8 +62,8 @@ public class PseudoField {
 
         if (name != null) {
             // Regex replace such that "path[9]/thing" -> "path/thing"
-            String nameNoIndices = name.replaceAll("\\[.*?]", "");
-            final boolean validPattern = new FieldDescriptor(nameNoIndices).globMatches(pattern);
+            name = name.replaceAll("\\[.*?]", "");
+            final boolean validPattern = new FieldDescriptor(name).globMatches(pattern);
             if (!validPattern) {
                 throw new IllegalArgumentException(String.format("The pattern '%s' will not match the field name '%s'. " +
                         "Are you sure you didn't mean to use '/%s'?", pattern, name, pattern));


### PR DESCRIPTION
When adding pseudonymization rules, the `name` of the field needs to match the `pattern`. However, when sending hierarchical data, you might index an array such that the `name` becomes `person_info/fnr[0]`, but the `pattern` is `person_info/fnr`, making the name not match the pattern. We remove the indices with a regex in order to make this fit.

Ideally, we should have a longer-term solution to this, but pattern-based traversal is so ubiquotous to `pseudo-core` that, in my opinion, it is not worth changing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/statisticsnorway/pseudo-service/149)
<!-- Reviewable:end -->
