### PR TITLE
Refresh roles dynamically

### DIFF
--- a/.nais/test/nais.yaml
+++ b/.nais/test/nais.yaml
@@ -111,6 +111,12 @@ data:
           other:
             num-threads: 100
             prefer-native-transport: true
+            
+      kubernetes:
+        client:
+          config-maps:
+            enabled: true
+            watch: true
 
       http:
         client:
@@ -199,8 +205,6 @@ data:
                     url: 'https://www.googleapis.com/oauth2/v3/certs'
                   lab-id-north1-test:
                     url: 'https://labid.lab.dapla-test-external.ssb.no/jwks'
-                  lab-id-west4-test:
-                    url: 'https://labid.lab.dapla-test.ssb.no/jwks'
                   lab-id-north1-dev:
                     url: 'https://labid.lab.dapla-dev-external.ssb.no/jwks'
 

--- a/pom.xml
+++ b/pom.xml
@@ -106,6 +106,11 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
+      <groupId>io.micronaut.kubernetes</groupId>
+      <artifactId>micronaut-kubernetes-discovery-client</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
       <groupId>no.ssb.dapla.metadata</groupId>
       <artifactId>datadoc-model</artifactId>
       <version>${dapla-datadoc-model.version}</version>

--- a/src/main/java/no/ssb/dlp/pseudo/service/security/CustomRolesFinder.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/security/CustomRolesFinder.java
@@ -28,7 +28,7 @@ import java.util.*;
 public class CustomRolesFinder implements RolesFinder {
 
     private final TokenConfiguration tokenConfiguration;
-    private final StaticRolesConfig rolesConfig;
+    private final DynamicRolesConfig rolesConfig;
     private final CloudIdentityService cloudIdentityService;
 
     @Override
@@ -49,13 +49,6 @@ public class CustomRolesFinder implements RolesFinder {
         // We check for trustedIssuer when in environments where all authenticated requests are accepted
         // This is due to Google tokens being valid for authorization purposes,
         // however they get no roles since they are not a trusted issuer.
-
-        email.ifPresent(e -> {
-            log.debug("Resolved email '{}'", e);
-            rolesConfig.getAdmins().forEach(a ->
-                    log.info("Admin candidate '{}', equals? {}", a, e.equals(a))
-            );
-        });
 
         if (rolesConfig.getAdmins().contains(SecurityRule.IS_AUTHENTICATED) && trustedIssuer
                 || email.map(rolesConfig.getAdmins()::contains).orElse(false)) {

--- a/src/main/java/no/ssb/dlp/pseudo/service/security/DynamicRolesConfig.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/security/DynamicRolesConfig.java
@@ -1,6 +1,8 @@
 package no.ssb.dlp.pseudo.service.security;
 
 import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.runtime.context.scope.Refreshable;
+import jakarta.inject.Singleton;
 import lombok.Data;
 
 import java.util.ArrayList;
@@ -9,7 +11,9 @@ import java.util.Optional;
 
 @ConfigurationProperties("app-roles")
 @Data
-public class StaticRolesConfig {
+@Singleton
+@Refreshable
+public class DynamicRolesConfig {
     private List<String> trustedIssuers = new ArrayList<>();
     private List<String> users = new ArrayList<>();
     private List<String> admins = new ArrayList<>();

--- a/src/test/java/no/ssb/dlp/pseudo/service/security/CustomRolesFinderTest.java
+++ b/src/test/java/no/ssb/dlp/pseudo/service/security/CustomRolesFinderTest.java
@@ -4,6 +4,7 @@ import com.nimbusds.jwt.JWTClaimNames;
 import io.micronaut.security.rules.SecurityRule;
 import io.micronaut.security.token.config.TokenConfiguration;
 import io.micronaut.security.token.config.TokenConfigurationProperties;
+import net.bytebuddy.utility.JavaConstant;
 import no.ssb.dlp.pseudo.service.accessgroups.CloudIdentityService;
 import no.ssb.dlp.pseudo.service.accessgroups.EntityKey;
 import no.ssb.dlp.pseudo.service.accessgroups.Membership;
@@ -19,7 +20,7 @@ import static org.mockito.Mockito.*;
 class CustomRolesFinderTest {
 
     CloudIdentityService cloudIdentityService = mock(CloudIdentityService.class);
-    StaticRolesConfig rolesConfig = mock(StaticRolesConfig.class);
+    DynamicRolesConfig rolesConfig = mock(DynamicRolesConfig.class);
     TokenConfiguration tokenConfig = new TokenConfigurationProperties();
     CustomRolesFinder sut = new CustomRolesFinder(tokenConfig, rolesConfig, cloudIdentityService);
 


### PR DESCRIPTION
This makes it so that when the underlying config map changes, the service will, under runtime, update the corresponding bean
